### PR TITLE
Suggesting wording to clarify tht okL<sub>R</sub>CH is not the same as okLCH

### DIFF
--- a/misc/colorpicker/index.html
+++ b/misc/colorpicker/index.html
@@ -15,7 +15,7 @@
 
     <section>
     <h2>Interactive color picker comparison</h2>
-    <p>Almost all color pickers are based on HSL or HSV, but that might not be the best choice. Here standard HSV and HSL color pickers are compared with Oklch, Okhsv, Okhsl and Hsluv. </p>
+    <p>Almost all color pickers are based on HSL or HSV, but that might not be the best choice. Here standard HSV and HSL color pickers are compared with Okhsv, Okhsl and Hsluv. Please note that OKL<sub>r</sub>CH is a variant of okLCH and will provide different luminence values than standard okLCH.</p>
     
     <p>For background and more information about the color spaces used, check out the accompanying <a href="https://bottosson.github.io/posts/colorpicker/">blog post</a>.</p>
     


### PR DESCRIPTION
Hello, I'm suggesting a small change to the language at the top of the page. The current language says (and certainly gave me) the incorrect impression that the colour picker is comparing okHSV to okLCH (i.e. that okL<sub>R</sub>CH is the same as okLCH). I don't think it's fair to assume people landing on this page have read the blog post (let alone in detail). As okHSV gains traction there are going to be more people, who like me, found about okHSV from other sources, and are arriving at the tool without the context about L<sub>R</sub>. It should be clear this is a _variant_ of okLCH with different luminence values. Thank you! :)